### PR TITLE
Fix a build break caused by a breaking change in MRPT.

### DIFF
--- a/src/rf2o_laser_odometry/src/CLaserOdometry2D.cpp
+++ b/src/rf2o_laser_odometry/src/CLaserOdometry2D.cpp
@@ -897,7 +897,7 @@ void CLaserOdometry2D::PoseUpdate()
 	laser_oldpose = laser_pose;
 	math::CMatrixDouble33 aux_acu = acu_trans;
 	poses::CPose2D pose_aux_2D(acu_trans(0,2), acu_trans(1,2), kai_loc(2)/fps);
-    laser_pose = laser_pose + pose_aux_2D;
+    laser_pose = laser_pose + poses::CPose3D(pose_aux_2D);
 
 
 


### PR DESCRIPTION
This fixes issue #2. Due to a breaking change in mrpt (https://github.com/MRPT/mrpt/commit/b9328569bd246a8ac1a67777aebdb16f3b3ad00e),

CPose2D can't be implicitly casted into CPose3D.

HOW BUILT
```bash
$ catkin_make_isolated --install --use-ninja
```

Change-Id: I52e1e5e9ad3027ad084181c9fe70ddbf7abb164e
Signed-off-by: Wei Ren <renwei@smartconn.cc>